### PR TITLE
Downgrading imageio-ffmpeg to 0.2.0 fixes the broken pipe command whe…

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - ftfy
   - pillow=7.1.2
   - python=3.8 # For compatibility
-  - imageio-ffmpeg
+  - imageio-ffmpeg=0.2.0 # For compatibility
   - ipykernel
   - imageio
   - ipywidgets


### PR DESCRIPTION
"Broken Pipe" error with imageio-ffmpeg 

Imageio-ffmpeg was crashing with a "Broken Pipe" error when app started to create the MP4 at the end of the processing.   

Found the suggestion below to downgrade imageio-ffmpeg to 0.2.0 and now the movie creation works.

https://github.com/lengstrom/fast-style-transfer/issues/253#issuecomment-777344545