### PR TITLE
Add Cutn to the web interface sidebar.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. Linux, Windows 10]
+ - Browser [e.g. Chrome, Safari, Brave]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.gitignore
+++ b/.gitignore
@@ -5,9 +5,13 @@
 # VQGAN weights
 assets/*.ckpt
 assets/*.yaml
+assets/*
 
 # Outputs
 output*
+
+# samples
+samples/*
 
 # Test data
 test-samples/

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,3 +1,3 @@
 [server]
 # Default is 200 MB
-maxUploadSize = 10
+maxUploadSize = 5000

--- a/app.py
+++ b/app.py
@@ -181,7 +181,7 @@ def generate_image(
             
             if num_steps > 0:
                 total_number_steps = f"/{num_steps}"
-                percent = f"%{100 * float(step_counter)/float(num_steps)}"
+                percent = f"{100 * float(step_counter)/float(num_steps):.2f}%"
             else:
                 total_number_steps = ""
                 percent = ""
@@ -585,7 +585,7 @@ if __name__ == "__main__":
             step_size = step_size.number_input(
                 "Custom Step Size or Learning Rate",
                 value=defaults["step_size"],
-                min_value=0.0001,
+                min_value=0.00001,
                 step=0.001,
                 help="Specify a custom Step Size or Learning Rate to use. Ref: https://en.wikipedia.org/wiki/Learning_rate",
                 format="%.5f",

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -11,6 +11,8 @@ cutn: 32
 cut_pow: 1.0
 custom_step_size: false
 step_size: 0.05
+use_custom_opt: false
+opt_name: Adam
 use_starting_image: false
 use_image_prompts: false
 continue_prev_run: false

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1,9 +1,11 @@
 # Modify for different systems, e.g. larger default xdim/ydim for more powerful GPUs
 num_steps: 500
-Xdim: 640
-ydim: 480
+Xdim: 511
+ydim: 511
 set_seed: false
 seed: 0
+use_cutn: true
+cutn: 32
 use_starting_image: false
 use_image_prompts: false
 continue_prev_run: false

--- a/defaults.yaml
+++ b/defaults.yaml
@@ -1,11 +1,16 @@
 # Modify for different systems, e.g. larger default xdim/ydim for more powerful GPUs
-num_steps: 500
-Xdim: 511
-ydim: 511
+use_clip_model: false
+clip_model: ViT-B/32
+num_steps: -1
+Xdim: 662
+ydim: 360
 set_seed: false
 seed: 0
-use_cutn: true
+use_cutn: false
 cutn: 32
+cut_pow: 1.0
+custom_step_size: false
+step_size: 0.05
 use_starting_image: false
 use_image_prompts: false
 continue_prev_run: false
@@ -13,5 +18,6 @@ mse_weight: 0.5
 mse_weight_decay: 0.1
 mse_weight_decay_steps: 50
 use_mse_regularization: false
-use_tv_loss_regularization: true
-tv_loss_weight: 1e-3
+use_tv_loss_regularization: false
+# best values for tv_loss_weight are 0.000085, 0.0001 or 0.0002
+tv_loss_weight: 0.000085

--- a/diffusion_app.py
+++ b/diffusion_app.py
@@ -100,7 +100,7 @@ def generate_image(
     frames = []
 
     try:
-        # Try block catches st.script_runner.StopExecution, no need of a dedicated stop button
+        # Try block catches st.StopExecution, no need of a dedicated stop button
         # Reason is st.form is meant to be self-contained either within sidebar, or in main body
         # The way the form is implemented in this app splits the form across both regions
         # This is intended to prevent the model settings from crowding the main body
@@ -181,7 +181,7 @@ def generate_image(
 
         status_text.text("Done!")  # End of run
 
-    except st.script_runner.StopException as e:
+    except st.StopException as e:
         # Dump output to dashboard
         print(f"Received Streamlit StopException")
         status_text.text("Execution interruped, dumping outputs ...")

--- a/environment.yml
+++ b/environment.yml
@@ -4,11 +4,11 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - pytorch::pytorch=1.10.0
-  - pytorch::torchvision=0.11.1
-  - cudatoolkit=10.2
+  - pytorch::pytorch=1.12.0
+  - pytorch::torchvision=0.13.1
+  - cudatoolkit=10.2 # The cudatoolkit library could also be updated to 11.3 but might give some troubles with older GPUs, for an RTX 3050 or higher cudatoolkit=11.3 is recommended.
   - omegaconf
-  - pytorch-lightning
+  - pytorch-lightning=1.5.8 # For compatibility
   - tqdm
   - regex
   - kornia

--- a/environment.yml
+++ b/environment.yml
@@ -32,6 +32,8 @@ dependencies:
     # - imgtag
     - einops
     - transformers
+    - torch-optimizer
+    - retry
     - git+https://github.com/openai/CLIP
     # For guided diffusion
     - lpips

--- a/logic.py
+++ b/logic.py
@@ -70,6 +70,7 @@ class VQGANCLIPRun(Run):
         image_prompts: List[Image.Image] = [],
         continue_prev_run: bool = False,
         seed: Optional[int] = None,
+        cutn: int = 32,
         mse_weight=0.5,
         mse_weight_decay=0.1,
         mse_weight_decay_steps=50,
@@ -98,6 +99,7 @@ class VQGANCLIPRun(Run):
         self.image_prompts = image_prompts
         self.continue_prev_run = continue_prev_run
         self.seed = seed
+        self.cutn = cutn
 
         # Setup ------------------------------------------------------------------------------
         # Split text by "|" symbol
@@ -121,7 +123,8 @@ class VQGANCLIPRun(Run):
             vqgan_config=f"assets/{vqgan_ckpt}.yaml",
             vqgan_checkpoint=f"assets/{vqgan_ckpt}.ckpt",
             step_size=0.05,
-            cutn=64,
+            #cutn=32,
+            cutn=cutn,
             cut_pow=1.0,
             display_freq=50,
             seed=seed,
@@ -213,6 +216,7 @@ class VQGANCLIPRun(Run):
         self.z_max = self.model.quantize.embedding.weight.max(dim=0).values[
             None, :, None, None
         ]
+
 
         if self.seed is not None:
             torch.manual_seed(self.seed)


### PR DESCRIPTION
This PR adds a small but kind of important QOL change that I made, it will add an option to customize the `Cutn` value from the web interface.

![image](https://user-images.githubusercontent.com/5977640/184522192-12c02c5c-06a7-4f53-97ad-258025df3e46.png)

By having an option to change the number of cuts or `cutn` value we can reduce the amount of VRAM the app uses and so we can use higher resolutions than we were able to use before, for comparison, when using the previous default value which was 64 cutn I could only use a resolution of up to 400x400 with my Nvidia RTX 3050, after having an option to customize the cutn when using a value of 32 cutn I can use a resolution up to 512x512 and with a value of 25 cutn I was able to get up 1024x1024 a couple of times before adding any other option. It does come with some downsides but it's better to have the option to adjust that value than not having it at all. With a lower number of cuts we use less VRAM but the quality of the result image also decrease, a higher number of cuts give a better quality but also uses more VRAM on your GPU, if I'm not mistaken this is the value that is sent to CLIP to match the image to the text prompt, the more cuts we sent the better idea CLIP has of our current image and so it can match the text to the image better.

I also modified the `environment.yml` file so we can use a newer version of `pytorch`, `torchvision` and `pytorch-lightning`.